### PR TITLE
Resolve merge conflicts: consolidate HTTP type definitions

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -8,10 +8,10 @@ pub mod escrow;
 pub mod health_check;
 pub mod helpers;
 pub mod projects;
-pub mod research_report; // ✅ This now points to the proper file
+pub mod research_report;
 pub mod support_tickets;
 pub mod transaction;
-pub mod types; // ✅ This now points to the proper file
+pub mod types;
 
 use std::sync::Arc;
 
@@ -72,78 +72,4 @@ async fn shutdown_signal() {
         _ = ctrl_c => {},
         _ = terminate => {},
     }
-}
-
-
-// ===== create_project.rs needs this =====
-#[derive(Debug, Deserialize)]
-pub struct CreateProjectRequest {
-    pub owner_address: String,
-    pub contract_address: String,
-    pub name: String,
-    pub description: String,
-    pub contact_info: String,
-    pub supporting_document_path: Option<String>,
-    pub project_logo_path: Option<String>,
-    pub repository_url: Option<String>,
-    pub tags: Vec<String>,
-    pub bounty_amount: Option<BigDecimal>,
-    pub bounty_currency: Option<String>,
-    pub bounty_expiry_date: Option<DateTime<chrono::Utc>>,
-}
-
-// ===== escrow.rs needs this =====
-#[derive(Debug, Deserialize)]
-pub struct AllocateBountyRequest {
-    pub wallet_address: String,
-    pub project_contract_address: String,
-    pub amount: BigDecimal,
-    pub currency: String,
-    pub bounty_expiry_date: Option<DateTime<chrono::Utc>>,
-}
-
-// ===== support_tickets.rs needs these =====
-#[derive(Debug, Deserialize)]
-pub struct OpenSupportTicketRequest {
-    pub subject: String,
-    pub message: String,
-    pub opened_by: String,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct AssignSupportTicketRequest {
-    pub ticket_id: Uuid,
-    pub support_agent_wallet: String,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct ResolveSupportTicketRequest {
-    pub ticket_id: String,
-    pub resolved_by: String,
-    pub resolution_response: String,
-}
-
-#[derive(Debug, Deserialize)]
-pub struct ListTicketsQuery {
-    pub status: Option<String>,
-    pub sort: Option<String>,
-    pub limit: Option<u32>,
-    pub offset: Option<i64>,
-}
-
-#[derive(Debug, Serialize, sqlx::FromRow)]
-pub struct SupportTicket {
-    pub id: String,
-    pub subject: String,
-    pub message: String,
-    pub document_path: Option<String>,
-    pub opened_by: String,
-    pub status: String,
-    pub assigned_to: Option<String>,
-    pub response_subject: Option<String>,
-    pub resolution_response: Option<String>,
-    pub resolved: Option<bool>,
-    pub created_at: String,
-    pub resolved_at: Option<String>,
-    pub updated_at: String,
 }

--- a/src/http/types.rs
+++ b/src/http/types.rs
@@ -13,10 +13,10 @@ pub struct CreateProjectRequest {
     pub supporting_document_path: Option<String>,
     pub project_logo_path: Option<String>,
     pub repository_url: Option<String>,
+    pub tags: Vec<String>,
     pub bounty_amount: Option<BigDecimal>,
     pub bounty_currency: Option<String>,
     pub bounty_expiry_date: Option<DateTime<Utc>>,
-    pub tags: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -25,7 +25,7 @@ pub struct AllocateBountyRequest {
     pub project_contract_address: String,
     pub amount: BigDecimal,
     pub currency: String,
-    pub bounty_expiry_date: DateTime<Utc>,
+    pub bounty_expiry_date: Option<DateTime<Utc>>,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
This PR resolves structural merge conflicts in the HTTP module by:

- Consolidating all type definitions into `src/http/types.rs` as the single source of truth
- Removing duplicate type definitions from `src/http/mod.rs`
- Ensuring consistent imports across all HTTP module files
- Resolving inconsistencies between `mod.rs` and `types.rs`
- All HTTP module files now correctly import from the centralized `types.rs`

The conflicts were structural - duplicate type definitions and inconsistencies between files. The resolution maintains backward compatibility while providing a clean, consistent codebase structure.